### PR TITLE
fix escapeToBuffer vulnerability

### DIFF
--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -5,7 +5,7 @@ export type StringBuffer = [string]
 // The `escapeToBuffer` implementation is based on code from the MIT licensed `react-dom` package.
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/server/escapeTextForBrowser.js
 
-const escapeRe = /[&<>"]/
+const escapeRe = /[&<>'"]/
 
 export const escapeToBuffer = (str: string, buffer: StringBuffer): void => {
   const match = str.search(escapeRe)
@@ -22,6 +22,9 @@ export const escapeToBuffer = (str: string, buffer: StringBuffer): void => {
     switch (str.charCodeAt(index)) {
       case 34: // "
         escape = '&quot;'
+        break
+      case 39: // '
+        escape = '&#39;'
         break
       case 38: // &
         escape = '&amp;'


### PR DESCRIPTION
Escape single quote (0x27) to limit execution capabilities under certain conditions.

Example, using JSX:
```tsx
const value = "alert('works')"
server.get("/*", c => <script>{value}</script>)
```

The condition under which it works are limited and should be avoided, but in reality its never as straightforward as in this simple example. Adjusted behavior mimics that of react-dom escaping single quotes.